### PR TITLE
Make qui-badge recyclable (e.g. in vaadin grid)

### DIFF
--- a/qui-badge.js
+++ b/qui-badge.js
@@ -104,8 +104,13 @@ export class QuiBadge extends LitElement {
     }
 
     connectedCallback() {
-        super.connectedCallback()
-        
+        super.connectedCallback();
+        this._resetTheme();
+        this._resetStyle();
+    }
+
+    _resetTheme() {
+        this._theme = "badge";
         if(this.level){
             this._theme = this._theme + " " + this.level;
         }
@@ -116,18 +121,21 @@ export class QuiBadge extends LitElement {
                 this._theme = this._theme + " primary";
             }
         }
-        
+
         if(this.small && !this.tiny){
             this._theme = this._theme + " small";
         }
         if(this.tiny){
             this._theme = this._theme + " tiny";
         }
-        
+
         if(this.pill){
             this._theme = this._theme + " pill";
         }
-        
+    }
+
+    _resetStyle() {
+        this._style = "";
         if(this.background){
             this._style = this._style + "background: " + this.background + ";";
         }
@@ -137,8 +145,17 @@ export class QuiBadge extends LitElement {
         if(this.clickable){
             this._style = this._style + "cursor: pointer";
         }
-      }
-      
+    }
+
+    update(changedProperties) {
+        this._resetTheme();
+        this._resetStyle();
+
+        // this will invoke re-rendering
+        super.update(changedProperties);
+    }
+
+
     render() {
         return html`<span theme='${this._theme}' style='${this._style}'>
                 ${this._renderIcon()}


### PR DESCRIPTION
@phillip-kruger, I currently want to extend the Quarkus Dev UI, and therefore I need to use the badge within a Vaadin grid. This grid seems to re-use components while rendering (a discussion about this was here: https://github.com/vaadin/flow-components/issues/1666), so the lifecycle of the web component is:

 - `connectedCallback()` is invoked once
 - `render()` is invoked once
 - when the user scrolls in the UI, the invisible components are re-used, so
   - `update(changedProperties)` is invoked
   - `render()` is invoked again

So this leads to wrong rendering when theme and style are initialized once, but not updated. See this screenshot, where `color` and `background` are not rendered correctly into the `style` of the `span`:

![Screenshot with inconsistent state](https://github.com/user-attachments/assets/1139b2a0-0e35-49df-9cba-3b39e5fc22a1)

What do you think, is my solution a valid one? (directly tested within Quarkus UI)

